### PR TITLE
Improve displaying of padding

### DIFF
--- a/pahole.py
+++ b/pahole.py
@@ -46,8 +46,10 @@ It prints the type and displays comments showing where holes are."""
 
             # Detect hole
             if endpos < field.bitpos:
-                hole = field.bitpos - endpos
-                print ('/* XXX %d bit hole, try to pack */' % hole)
+                hole = (field.bitpos - endpos) // 8
+                print ('/* XXX %4d */ !!' % hole, end="")
+                print (' ' * (4 + 2 * level - 3), end="")
+                print ('char __padding__[%d]' % hole)
 
             # Are we a bitfield?
             if field.bitsize > 0:

--- a/pahole.py
+++ b/pahole.py
@@ -49,7 +49,7 @@ It prints the type and displays comments showing where holes are."""
                 hole = (field.bitpos - endpos) // 8
                 print ('/* XXX %4d */ !!' % hole, end="")
                 print (' ' * (4 + 2 * level - 3), end="")
-                print ('char __padding__[%d]' % hole)
+                print ('char [%d] __%d_bit_padding__' % (hole, 8*hole))
 
             # Are we a bitfield?
             if field.bitsize > 0:
@@ -68,6 +68,13 @@ It prints the type and displays comments showing where holes are."""
 #            else:
             print (' ' * (4 + 2 * level), end="")
             print ('%s %s' % (str (ftype), field.name))
+
+        # Check for padding at the end
+        if endpos // 8 < atype.sizeof:
+            hole = atype.sizeof - endpos // 8
+            print ('/* XXX %4d */ !!' % hole, end="")
+            print (' ' * (4 + 2 * level - 3), end="")
+            print ('char [%d] __%d_bit_padding__' % (hole, 8*hole))
 
         print (' ' * (14 + 2 * level), end="")
         print ('} %s' % name)


### PR DESCRIPTION
This PR seeks to make the displaying of padding more natural by
1. Showing padding as inline `char` array of some size, emphasis given through `XXX` and `!!` at the beginning.
2. Showing padding at the end of an object to make the entire object aligned
    This is especially important on ARM where some instructions (such as `LDM` and `STC`) require *strict alignment*.

----

## Example 1

``` c
#define TYPE_MAX 17
struct {
	unsigned char magic;
	int total;
	int blocked;
	int cached;
	int forwarded;
	time_t timestamp;
	int querytypedata[TYPE_MAX-1];
} overTimeData;
```

Output on `master`:

``` plain
pahole overTimeData

/*   88     */ struct  {
/*   0    1 */    unsigned char magic
/* XXX 24 bit hole, try to pack */
/*   4    4 */    int total
/*   8    4 */    int blocked
/*  12    4 */    int cached
/*  16    4 */    int forwarded
/*  20    4 */    long int timestamp
/*  24   64 */    int [16] querytypedata
              }
```

Output on my branch:
``` plain
pahole overTimeData

/*   88     */ struct  {
/*   0    1 */    unsigned char magic
/* XXX    3 */ !! char [3] __24_bit_padding__
/*   4    4 */    int total
/*   8    4 */    int blocked
/*  12    4 */    int cached
/*  16    4 */    int forwarded
/*  20    4 */    long int timestamp
/*  24   64 */    int [16] querytypedata
              }
```
This shows what happens on padding inside the object.

## Example 2

``` c
typedef struct {
	pthread_mutex_t lock;
	bool waitingForLock;
} ShmLock;
```

Output on `master`:

``` plain
pahole ShmLock

/*   28     */ struct  {
/*   0   24 */    union {...} lock
/*  24    1 */    _Bool waitingForLock
              } 
```

Output on my branch:
``` plain
pahole ShmLock

/*   28     */ struct  {
/*   0   24 */    union {...} lock
/*  24    1 */    _Bool waitingForLock
/* XXX    3 */ !! char [3] __24_bit_padding__
              } 
```
This shows what happens on padding at the end of an object. Note that the information is absent (visible only indirectly) on current `master`.

## Example 3

Same `struct ShmLock` as above but modified `pahole` to also analyze the internals of the `union` (not included in this PR) shows that this also works in `union`s and nested structures:
```
/*   28     */ struct  {
/*   0   24 *//*   24     */   union  {
/*   0   24 *//*   24     */     struct __pthread_mutex_s {
/*   0    4 */        int __lock
/*   4    4 */        unsigned int __count
/*   8    4 */        int __owner
/*  12    4 */        int __kind
/*  16    4 */        unsigned int __nusers
/*  20    4 *//*    4     */       union  {
/*   0    4 *//*    4     */         struct  {
/*   0    2 */            short int __espins
/*   2    2 */            short int __elision
                      } __elision_data
/*   0    4 *//*    4     */         struct __pthread_internal_slist {
/*   0    4 */            struct __pthread_internal_slist * __next
                      } __list
                    } 
                  } __data
/*   0   24 */      char [24] __size
/*   0    4 */      long int __align
/* XXX   20 */ !!   char [20] __160_bit_padding__
                } lock
/*  24    1 */    _Bool waitingForLock
/* XXX    3 */ !! char [3] __24_bit_padding__
              }
```