### PR TITLE
Add walk command and improve bitfield handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ directory where you installed the python scripts.
 Then invoke gdb on your compiled binary and check the offsets of your
 C++ or C classes and structs like so:
 
-```
+``` plain
 $ gdb test-pahole
 GNU gdb (Debian 10.1-1.7) 10.1.90.20210103-git
 ...
@@ -24,7 +24,41 @@ Reading symbols from test-pahole...
 /* XXX    3 */ !! char [3] __24_bit_padding__
 /*   8    8 */    void * l
               } 
-(gdb)
+
+(gdb) pahole testStruct
+/*  152     */ struct testStruct {
+/*   0    2 */     short a
+/*   2    1 */     char b
+/* XXX    5 */ !!  char [5] __40_bit_padding__
+/*   8  144 */     testStruct::more_struct more
+               } testStruct
+```
+
+When specifying `walk` right after the type name, `pahole` will walk your object recursively and reveal the content of nested `struct`s and `union`s:
+
+``` plain
+(gdb) pahole testStruct walk
+/*  152     */ struct testStruct {
+/*   0    2 */     short a
+/*   2    1 */     char b
+/* XXX    5 */ !!  char [5] __40_bit_padding__
+/*   8  144 */     struct testStruct::more_struct {
+/*   0  128 */       union testStruct::more_struct::union_x {
+/*   0  128 */         char [128] c
+/*   0    2 */         struct testStruct::more_struct::union_x::s_y {
+/*   0    1 */           char v
+/*   1    0 */           char g1_1:7
+/* XXX    1 */ !!        char [1] __1_bit_padding__
+                     } y
+/* XXX 1008 */ !!      char [126] __1008_bit_padding__
+                   } x
+/* 128    8 */       long e
+/* 136    0 */       char s1_1:1
+/* 136    0 */       char s1_2:1
+/* 136    0 */       char s2:2
+/* XXX   60 */ !!    char [8] __60_bit_padding__
+                 } more
+               } testStruct
 ```
 
 Python compatibility

--- a/test-pahole.cc
+++ b/test-pahole.cc
@@ -15,6 +15,28 @@ public:
     void * getl() { return l; }
 };
 
+extern "C" {
+  typedef struct {
+    short a;
+    char b;
+    struct more_struct {
+      union union_x
+      {
+        char c[128];
+        struct s_y
+        {
+          char v;
+          char g1_1:7;
+        } y;
+      } x;
+      long e;
+      char s1_1:1;
+      char s1_2:1;
+      char s2:2;
+    } more;
+  } testStruct;
+}
+
 using namespace std;
 
 int main() {
@@ -24,5 +46,9 @@ int main() {
     cout << c.geti() << " ";
   }
   cout << endl;
+
+  testStruct a;
+  a.a = 100;
+  cout << a.a << endl;
   return 0;
 }


### PR DESCRIPTION
This PR adds an option `walk` that can be given to `pahole` to walk objects recursively. In addition, I added displaying the number of bits a bitfield uses in case the user specified this (I frequently do this to store several `bool`s in one byte and still conveniently access them).

Assume the following complex test struct (also added to the test source file):
``` c
typedef struct {
  short a;
  char b;
  struct more_struct {
    union union_x
    {
      char c[128];
      struct s_y
      {
        char v;
        char g1_1:7;
      } y;
    } x;
    long e;
    char s1_1:1;
    char s1_2:1;
    char s2:2;
  } more;
} testStruct;
```

`pahole` outputs:
``` plain
(gdb) pahole testStruct
/*  152     */ struct testStruct {
/*   0    2 */     short a
/*   2    1 */     char b
/* XXX    5 */ !!  char [5] __40_bit_padding__
/*   8  144 */     testStruct::more_struct more
                 } 
```

With the new `walk` option, the entire structure can be analyzed:
``` plain
(gdb) pahole testStruct walk
/*  152     */ struct testStruct {
/*   0    2 */     short a
/*   2    1 */     char b
/* XXX    5 */ !!  char [5] __40_bit_padding__
/*   8  144 */     struct testStruct::more_struct {
/*   0  128 */       union testStruct::more_struct::union_x {
/*   0  128 */         char [128] c
/*   0    2 */         struct testStruct::more_struct::union_x::s_y {
/*   0    1 */           char v
/*   1    0 */           char g1_1:7                      <--- see manually configured bitsize of 7 bits
/* XXX    1 */ !!        char [1] __1_bit_padding__       <--- accordingly, we pad only with one bit here
                       } y
/* XXX 1008 */ !!      char [126] __1008_bit_padding__
                     } x
/* 128    8 */       long e
/* 136    0 */       char s1_1:1
/* 136    0 */       char s1_2:1
/* 136    0 */       char s2:2
/* XXX   60 */ !!    char [8] __60_bit_padding__          <--- padding with 64 - (2*1 + 1*2) = 60 bits
                   } more
                 } 
```
(comments added by me starting in `<---` are not given in the output)